### PR TITLE
Add authenticated user endpoint

### DIFF
--- a/server/auth.test.js
+++ b/server/auth.test.js
@@ -56,4 +56,21 @@ describe('auth routes', () => {
       .send({ username: '', password: '123' });
     expect(res.status).toBe(400);
   });
+
+  test('returns current user with valid token', async () => {
+    const registerRes = await request(app)
+      .post('/auth/register')
+      .send({ username: 'erin', password: 'password123' });
+    const token = registerRes.body.token;
+    const res = await request(app)
+      .get('/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ username: 'erin' });
+  });
+
+  test('rejects request without token', async () => {
+    const res = await request(app).get('/auth/me');
+    expect(res.status).toBe(401);
+  });
 });

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -80,6 +80,24 @@ router.post('/login', async (req, res) => {
   }
 });
 
+router.get('/me', (req, res) => {
+  const authHeader = req.headers.authorization || '';
+  const [, token] = authHeader.split(' ');
+  if (!token) {
+    return res.status(401).json({ error: 'Missing token' });
+  }
+  try {
+    const payload = jwt.verify(token, jwtSecret);
+    const user = users.get(payload.username);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+    return res.json({ username: user.username });
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+});
+
 function resetUsers() {
   users.clear();
   saveUsers(users);


### PR DESCRIPTION
## Summary
- add `/auth/me` route to return current user when supplied a valid JWT token
- test fetching current user and missing token error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94eb39b7c8330b9a7db30cf8a5954